### PR TITLE
Tweaks for integration into valis

### DIFF
--- a/sdss_explorer/pages/__init__.py
+++ b/sdss_explorer/pages/__init__.py
@@ -19,10 +19,13 @@ def Page():
 
     # PAGE TITLE
     # TODO: make this adaptive in some cool way
-    sl.Title("(NOTPUBLIC) SDSS Visboard")
+    sl.Title("SDSS Visboard")
     with sl.AppBar():
+        # TODO - post collab meeting
+        # TODO - add query parameter option for the data release
+        # TODO - update the title with release from query parameter
         # main title object
-        sl.AppBarTitle(children=[rv.Icon(children=["mdi-orbit"]), " SDSS"])
+        sl.AppBarTitle(children=["IPL-3 Parameter Explorer"])
 
     # SIDEBAR
     sidebar()
@@ -34,9 +37,11 @@ def Page():
 
 @sl.component
 def Layout(children):
-    # route, routes = sl.use_route()
+    # force remove the navigation tabs from solara app layout
+    route, routes = sl.use_route()
 
-    return sl.AppLayout(sidebar_open=False, children=children, color="purple")
+    # use vuetify material design color grey-darken-3 ; can pick new color later
+    return sl.AppLayout(sidebar_open=True, children=children, color="#424242")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR makes some tweaks for integration into Valis / Zora.  It adds the `use_route` into the main Layout, which forces the removal of the page navigation tabs.  It changes the AppBar title to a more descriptive title, specific to IPL-3 for now.  It also changes the color of the app bar, which we can change later if we want.  Here is what it looks like integrated into Zora.  

<img width="1704" alt="Screenshot 2024-05-15 at 11 30 50 AM" src="https://github.com/sdss/explorer/assets/1836302/1e7b1aa2-768f-4b1d-9862-79493b496050">
