### PR TITLE
Updates the explorer for DR20

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,15 @@ New datafiles for the dashboard must be generated each time the source SDSS summ
 - **(release)**: a directory for each data release
    - **columnsAll(Star|Visit)-`(astra_version)`.json**: JSON files providing a list of all columns for each catalog file used in the dashboard. One file per star/visit catalogs.
    - **explorerAll(Star|Visit)-`(astra_version)`.hdf5**: HDF5 files of the summary catalogs aggregated into a single file. One file per star/visit catalogs.
-- **dr19_dminfo.json**: a JSON of the datamodel column descriptions of the catalog summary files, used for populating the dashboard column glossary.
-- **mappings.parquet**: compiled datafile of all the sdss targeting cartons and programs
+   - **(release)_dminfo.json**: a JSON of the datamodel column descriptions of the catalog summary files, used for populating the dashboard column glossary.
+   - **mappings_(release).parquet**: compiled datafile of all the sdss targeting cartons and programs bit flags from semaphore
+- **dr19_dminfo.json**: (Deprecated location) a JSON of the datamodel column descriptions of the catalog summary files, used for populating the dashboard column glossary.
+- **mappings.parquet**: A deprecated DR19-specific version of the bitmaps file, possibly around for backwards compatibility.
 - **explorer**: a directory used as a scratch space for user's downloading subsets via the dashboard.
 
 New `columnsXXX.json` and `explorerXXX.hdf5` files are generated following instructions at https://github.com/sdss/explorer-filegen.  Also see the docs at [Explorer Dev DataFiles](https://sdss.github.io/explorer/developer/datafiles/).
 
-`dr19_dminfo.json` contains, for each datamodel column name, the following fields: `name`, `description`, `type`, `unit`. Original version of this file was the `ipl3_partial.json`.  This file can be produced by running `scripts/gen_datamodel_ref.py`.
+`(release)_dminfo.json` contains, for each datamodel column name, the following fields: `name`, `description`, `type`, `unit`. Original version of this file was the `ipl3_partial.json`.  This file can be produced by running `scripts/gen_datamodel_ref.py`.
 
 ## Starting the server
 To run, the environment variables must be exported to the shell environment. The base ones are:
@@ -157,6 +159,31 @@ uvicorn valis.wsgi:app --reload
 ```
 
 The local web server is exposed at `http://localhost:8000`, with the solara app at `http://localhost:8000/valis/solara/dashboard`.
+
+
+## Structure of Project
+
+This describes the structure of the `src/sdss_explorer` project.
+
+- `assets/`: application assets bundled with the package.
+- `assets/help/`: help content and icons for dashboard tooltips/help UI.
+- `dashboard/`: Solara dashboard application and state management logic.
+- `dashboard/components/`: reusable UI component modules used by the dashboard.
+- `dashboard/components/sidebar/`: sidebar-specific UI and filter controls.
+- `dashboard/components/views/`: plotting, grid, and dataframe view components.
+- `dashboard/dataclass/`: dataclass-based state containers for alerts, plots, subsets, and grid state.
+- `dashboard/util/`: dashboard helper utilities (I/O, regex helpers, and other support logic).
+- `server/`: FastAPI backend for rendering/filtering datasets and handling download jobs.
+- `util/`: shared package utilities (configuration, logging, filtering, and common helpers).
+- `vue/`: custom Vue component files integrated into the dashboard frontend.
+
+Typical dashboard workflow when the app starts:
+
+- Initializes the page component (the `Page()` component in `dashboard/__init__.py`)
+- Sets state and loads datasets (via `State.load_dataset()` in `dashboard/dataclass/state.py`)
+- Sidebar subset creation and filtering (via `SubsetState` in `dashboard/components/sidebar/subset_ui.py` and `subset_filters.py`)
+- Clicking **Add View** in calls `add_view()` to create a plot card and `PlotState` (in `dashboard/components/views/grid.py`).
+- A chart type is rendered in `dashboard/components/views/plots.py` (`HistogramPlot`, `ScatterPlot`, `HeatmapPlot`, etc.), where aggregations and callbacks are applied to the currently selected subset.
 
 
 ---

--- a/src/sdss_explorer/dashboard/__init__.py
+++ b/src/sdss_explorer/dashboard/__init__.py
@@ -46,8 +46,6 @@ setup_logging(
 
 logger = logging.getLogger("dashboard")
 
-# State = StateData()
-
 
 def on_start():
     """Startup function, runs on every kernel instance startup and sets (some) unique sesion parameters."""

--- a/src/sdss_explorer/dashboard/__init__.py
+++ b/src/sdss_explorer/dashboard/__init__.py
@@ -42,6 +42,7 @@ setup_logging(
 
 logger = logging.getLogger("dashboard")
 
+#State = StateData()
 
 def on_start():
     """Startup function, runs on every kernel instance startup and sets (some) unique sesion parameters."""
@@ -146,7 +147,7 @@ def Page() -> None:
             if datatype == "visit":
                 query_params.update({"dataset": "thepayne"})
             else:
-                query_params.update({"dataset": "mwmlite"})
+                query_params.update({"dataset": "bossnet"})
 
         # parse subset/plot initializes
         if len(query_params) > 0:

--- a/src/sdss_explorer/dashboard/__init__.py
+++ b/src/sdss_explorer/dashboard/__init__.py
@@ -3,33 +3,37 @@
 import logging
 from urllib.parse import parse_qs
 
-from bokeh.io import output_notebook
-import solara as sl
 import numpy as np
+import solara as sl
 import vaex as vx
+from bokeh.io import output_notebook
 from solara.lab import ThemeToggle
 
 # vaex setup
 # NOTE: vaex gets its cache settings from envvars, see README.md
 if sl.server.settings.main.mode == "production":
-    vx.logging.remove_handler(
-    )  # force remove handler prior to any imports on production
+    vx.logging.remove_handler()  # force remove handler prior to any imports on production
 vx.cache.on()  # activate caching
 
-from .dataclass import (
-    State,
-    Subset,
-    SubsetStore,
-    AlertSystem,
-    Alert,
-    SubsetState,
-)  # noqa: E402
-from ..util import settings, validate_release, validate_pipeline, setup_logging  # noqa: E402
+from ..util import (  # noqa: E402
+    settings,
+    setup_logging,
+    validate_pipeline,
+    validate_release,
+)
 from .components.sidebar import Sidebar  # noqa: E402
 from .components.sidebar.glossary import HelpBlurb  # noqa: E402
 from .components.sidebar.subset_filters import flagList  # noqa: E402
 from .components.views import ObjectGrid, add_view  # noqa: E402
 from .components.views.dataframe import NoDF  # noqa: E402
+from .dataclass import (
+    Alert,
+    AlertSystem,
+    State,
+    Subset,
+    SubsetState,
+    SubsetStore,
+)  # noqa: E402
 
 # logging setup
 PROD = sl.server.settings.main.mode == "production"
@@ -42,7 +46,8 @@ setup_logging(
 
 logger = logging.getLogger("dashboard")
 
-#State = StateData()
+# State = StateData()
+
 
 def on_start():
     """Startup function, runs on every kernel instance startup and sets (some) unique sesion parameters."""
@@ -79,8 +84,7 @@ def Page() -> None:
     """
     df = State.df.value
 
-    output_notebook(
-        hide_banner=True)  # required so plots can exist; loads BokehJS
+    output_notebook(hide_banner=True)  # required so plots can exist; loads BokehJS
 
     # check query params
     # NOTE: query params are not avaliable on kernel load, so it must be an effect.
@@ -164,8 +168,7 @@ def Page() -> None:
             subset_keys = ["dataset", "expression"]
             list_subset_keys = ["mapper", "carton", "flags"]
             subset_data = {
-                k: v.split(",") if
-                ((k in list_subset_keys) & (len(v) > 0)) else v
+                k: v.split(",") if ((k in list_subset_keys) & (len(v) > 0)) else v
                 for k, v in query_params.items()
                 if k in subset_keys + list_subset_keys
             }
@@ -174,32 +177,40 @@ def Page() -> None:
             if subset_data:
                 try:
                     if subset_data.get("dataset"):
-                        assert validate_pipeline(State.df.value,
-                                                 subset_data.get("dataset"))
+                        assert validate_pipeline(
+                            State.df.value, subset_data.get("dataset")
+                        )
                     if subset_data.get("flags"):
-                        assert all({
-                            flag in list(flagList.keys())
-                            for flag in subset_data.get("flags")
-                        }), "flags failed"
+                        assert all(
+                            {
+                                flag in list(flagList.keys())
+                                for flag in subset_data.get("flags")
+                            }
+                        ), "flags failed"
                     if subset_data.get("mapper"):
                         assert all(
                             np.isin(
                                 subset_data.get("mapper"),
                                 State.mapping.value["mapper"].unique(),
                                 assume_unique=True,
-                            )), "mapper failed"
+                            )
+                        ), "mapper failed"
                     if subset_data.get("carton"):
                         assert all(
                             np.isin(
                                 subset_data.get("carton"),
                                 State.mapping.value["alt_name"].unique(),
                                 assume_unique=True,
-                            )), "carton failed"
+                            )
+                        ), "carton failed"
 
                     expr = subset_data.get("expression")
                     if expr:
-                        expr = (expr.replace(".and.", " & ").replace(
-                            ".or.", " | ").replace(".eq.", "=="))
+                        expr = (
+                            expr.replace(".and.", " & ")
+                            .replace(".or.", " | ")
+                            .replace(".eq.", "==")
+                        )
                         State.df.value.validate_expression(expr)
                         subset_data["expression"] = expr
                 except Exception as e:
@@ -207,12 +218,18 @@ def Page() -> None:
 
                 # set first subset dataframe and columns
                 try:
-                    subset_data["df"]: vx.DataFrame = (State.df.value[
-                        State.df.
-                        value[f"(pipeline=='{subset_data.get('dataset')}')"]].
-                                                       copy().extract())
+                    subset_data["df"]: vx.DataFrame = (
+                        State.df.value[
+                            State.df.value[
+                                f"(pipeline=='{subset_data.get('dataset')}')"
+                            ]
+                        ]
+                        .copy()
+                        .extract()
+                    )
                     subset_data["columns"] = State.columns.value[
-                        subset_data.get("dataset")]
+                        subset_data.get("dataset")
+                    ]
 
                     # generate subset and update
                     subsets = {"s0": Subset(**subset_data)}

--- a/src/sdss_explorer/dashboard/components/views/grid.py
+++ b/src/sdss_explorer/dashboard/components/views/grid.py
@@ -4,7 +4,6 @@ import os
 from datetime import datetime
 from typing import Optional
 
-from bokeh.io import output_notebook
 import ipyvuetify as v
 import ipywidgets as widgets
 import reacton as r
@@ -37,9 +36,6 @@ class GridLayout(v.VuetifyTemplate):
     items = t.Union([t.List(), t.Dict()],
                     default_value=[]).tag(sync=True,
                                           **widgets.widget_serialization)
-    toolbar_items = t.Union([t.List(), t.Dict()],
-                            default_value=[]).tag(sync=True,
-                                                  **widgets.widget_serialization)
     # Selected grid item index whose toolbar cog was clicked in the Vue header.
     selected_settings_i = t.CInt(-1).tag(sync=True)
     grid_layout = t.List(default_value=[]).tag(sync=True)
@@ -151,11 +147,9 @@ def ObjectGrid():
                                                GridState.grid_layout.value[q + 1:])
                 GridState.states.value = (GridState.states.value[:q] +
                                           GridState.states.value[q + 1:])
-                GridState.objects.value[i] = rv.Card()
-                if i < len(GridState.toolbar_objects.value):
-                    toolbar_items = GridState.toolbar_objects.value.copy()
-                    toolbar_items[i] = rv.Card(flat=True, elevation=0)
-                    GridState.toolbar_objects.value = toolbar_items
+                if q < len(GridState.objects.value):
+                    GridState.objects.value = (GridState.objects.value[:q] +
+                                               GridState.objects.value[q + 1:])
                 break
 
     def reset_layout():
@@ -163,7 +157,6 @@ def ObjectGrid():
         GridState.index.value = 0
         GridState.grid_layout.value = []
         GridState.objects.value = []
-        GridState.toolbar_objects.value = []
         GridState.states.value = []
         GridState.index.value = 0
 
@@ -388,7 +381,7 @@ def ObjectGrid():
                                         )
         GridDraggableToolbar(
             items=GridState.objects.value,
-            toolbar_items=GridState.toolbar_objects.value,
+            #toolbar_items=GridState.toolbar_objects.value,
             # Vue toolbar cog writes an item id here; Python reacts by opening settings.
             selected_settings_i=selected_settings_i,
             on_selected_settings_i=set_selected_settings_i,

--- a/src/sdss_explorer/dashboard/components/views/grid.py
+++ b/src/sdss_explorer/dashboard/components/views/grid.py
@@ -14,9 +14,10 @@ import traitlets as t
 from solara.components.file_drop import FileInfo
 from solara.lab import Menu
 
-from ...dataclass import Alert, GridState, State, Subset, SubsetState, VCData
+from ...dataclass import Alert, GridState, PlotState, State, Subset, SubsetState, VCData
 from ...util.io import export_layout, export_subset, export_vcdata
 from ..dialog import Dialog
+from .plot_settings import show_settings
 from .plots import index_context, show_plot
 
 logger = logging.getLogger("dashboard")
@@ -36,6 +37,11 @@ class GridLayout(v.VuetifyTemplate):
     items = t.Union([t.List(), t.Dict()],
                     default_value=[]).tag(sync=True,
                                           **widgets.widget_serialization)
+    toolbar_items = t.Union([t.List(), t.Dict()],
+                            default_value=[]).tag(sync=True,
+                                                  **widgets.widget_serialization)
+    # Selected grid item index whose toolbar cog was clicked in the Vue header.
+    selected_settings_i = t.CInt(-1).tag(sync=True)
     grid_layout = t.List(default_value=[]).tag(sync=True)
     draggable = t.CBool(True).tag(sync=True)
     resizable = t.CBool(True).tag(sync=True)
@@ -46,30 +52,20 @@ GridDraggableToolbar = r.core.ComponentWidget(GridLayout)
 
 @sl.component()
 def ViewCard(plottype, i, **kwargs):
-
-    def remove(i):
-        """
-        i: unique identifier key, position in objects list
-        q: specific, adaptive index in grid_objects (position dict)
-        """
-        # find where in grid_layout has key (i)
-        for n, obj in enumerate(GridState.grid_layout.value):
-            if obj["i"] == i:
-                q = n
-                break
-
-        # cut layout and states at that spot
-        GridState.grid_layout.value = (GridState.grid_layout.value[:q] +
-                                       GridState.grid_layout.value[q + 1:])
-        GridState.states.value = (GridState.states.value[:q] +
-                                  GridState.states.value[q + 1:])
-
-        # replace the object in object list with a dummy renderable
-        # INFO: cannot be deleted because it breaks all renders
-        GridState.objects.value[i] = rv.Card()
-
     index_context.provide(i)  # used to access height data for dynamic resize
-    main = show_plot(plottype, lambda: remove(i), **kwargs)  # plot shower
+    current_key = sl.use_memo(
+        lambda: list(SubsetState.subsets.value.keys())[-1],
+        dependencies=[])
+    plotstate = PlotState(plottype, current_key, **kwargs)
+
+    def add_to_grid():
+        """Adds a pointer/reference to PlotState instance in GridState for I/O."""
+        GridState.states.set(list(GridState.states.value + [plotstate]))
+        return None
+
+    sl.use_memo(add_to_grid, dependencies=[])
+
+    main = show_plot(plottype, plotstate)  # plot shower
 
     logger.debug("returning viewcard now")
     return main
@@ -85,13 +81,14 @@ def add_view(plottype, layout: Optional[dict] = None, **kwargs):
         maxH = 40
         minH = 7
         if plottype == "stats":
-            height = 7
+            height = 6
+            minH = 6
         elif plottype == "targets":
-            height = 9
-            maxH = 9
-            minH = 9
+            height = 8
+            maxH = 8
+            minH = 8
         else:
-            height = 10
+            height = 9
         # horizontal or vertical offset depending on width
         if 12 - prev["w"] - prev["x"] >= 6:
             # beside
@@ -134,15 +131,44 @@ def ObjectGrid():
     impmenu, set_impmenu = sl.use_state(False)
     lockout, set_lockout = sl.use_state(False)
     areyousure, set_areyousure = sl.use_state(False)
+    # Mirrored from GridLayout.selected_settings_i; drives the settings dialog target.
+    selected_settings_i, set_selected_settings_i = sl.use_state(-1)
+
+    def _state_for_view_index(i: int):
+        """Return PlotState for a grid item id (`i`) by aligning with grid_layout ordering."""
+        for q, obj in enumerate(GridState.grid_layout.value):
+            if obj["i"] == i and q < len(GridState.states.value):
+                return GridState.states.value[q]
+        return None
+
+    selected_plotstate = _state_for_view_index(selected_settings_i)
+
+    def _remove_by_view_index(i: int):
+        """Remove one grid view by id and keep layout/state/object collections consistent."""
+        for q, obj in enumerate(GridState.grid_layout.value):
+            if obj["i"] == i:
+                GridState.grid_layout.value = (GridState.grid_layout.value[:q] +
+                                               GridState.grid_layout.value[q + 1:])
+                GridState.states.value = (GridState.states.value[:q] +
+                                          GridState.states.value[q + 1:])
+                GridState.objects.value[i] = rv.Card()
+                if i < len(GridState.toolbar_objects.value):
+                    toolbar_items = GridState.toolbar_objects.value.copy()
+                    toolbar_items[i] = rv.Card(flat=True, elevation=0)
+                    GridState.toolbar_objects.value = toolbar_items
+                break
 
     def reset_layout():
+        """Reset all grid-managed view containers and state references."""
         GridState.index.value = 0
         GridState.grid_layout.value = []
         GridState.objects.value = []
+        GridState.toolbar_objects.value = []
         GridState.states.value = []
         GridState.index.value = 0
 
     def set_grid_layout(data):
+        """Persist updated layout emitted by the draggable/resizable grid widget."""
         GridState.grid_layout.value = data
 
     def import_applayout(fileobj: FileInfo) -> None:
@@ -287,6 +313,25 @@ def ObjectGrid():
                 on_cancel=lambda *_: set_areyousure(False),
             )
 
+            with Dialog(
+                    open=selected_plotstate is not None,
+                    ok=None,
+                    ok_enable=False,
+                    title="Plot settings",
+                    cancel="Close",
+                    max_width=960,
+                    on_cancel=lambda *_: set_selected_settings_i(-1),
+            ):
+                if selected_plotstate is not None:
+                    show_settings(selected_plotstate.plottype, selected_plotstate)
+                    sl.Button(
+                        icon_name="mdi-delete",
+                        color="red",
+                        block=True,
+                        on_click=lambda *_: (_remove_by_view_index(selected_settings_i),
+                                             set_selected_settings_i(-1)),
+                    )
+
             btn2 = sl.Button(
                 "Layout options",
                 outlined=False,
@@ -343,6 +388,10 @@ def ObjectGrid():
                                         )
         GridDraggableToolbar(
             items=GridState.objects.value,
+            toolbar_items=GridState.toolbar_objects.value,
+            # Vue toolbar cog writes an item id here; Python reacts by opening settings.
+            selected_settings_i=selected_settings_i,
+            on_selected_settings_i=set_selected_settings_i,
             grid_layout=GridState.grid_layout.value,
             on_grid_layout=set_grid_layout,
             resizable=True,

--- a/src/sdss_explorer/dashboard/components/views/grid.py
+++ b/src/sdss_explorer/dashboard/components/views/grid.py
@@ -147,9 +147,12 @@ def ObjectGrid():
                                                GridState.grid_layout.value[q + 1:])
                 GridState.states.value = (GridState.states.value[:q] +
                                           GridState.states.value[q + 1:])
-                if q < len(GridState.objects.value):
-                    GridState.objects.value = (GridState.objects.value[:q] +
-                                               GridState.objects.value[q + 1:])
+                # Keep object slots indexed by stable view id for Vue lookups: items[item.i].
+                objects = GridState.objects.value.copy()
+                if i >= len(objects):
+                    objects.extend([rv.Card() for _ in range(i - len(objects) + 1)])
+                objects[i] = rv.Card()
+                GridState.objects.value = objects
                 break
 
     def reset_layout():
@@ -381,7 +384,6 @@ def ObjectGrid():
                                         )
         GridDraggableToolbar(
             items=GridState.objects.value,
-            #toolbar_items=GridState.toolbar_objects.value,
             # Vue toolbar cog writes an item id here; Python reacts by opening settings.
             selected_settings_i=selected_settings_i,
             on_selected_settings_i=set_selected_settings_i,

--- a/src/sdss_explorer/dashboard/components/views/plot_effects.py
+++ b/src/sdss_explorer/dashboard/components/views/plot_effects.py
@@ -110,12 +110,12 @@ def add_common_effects(
         if isinstance(fig_widget, BokehModel):
             fig_model = fig_widget._model
             with fig_model.hold(render=True):
-                if debounced_height.finished:
-                    if height == debounced_height.value:
-                        fig_model.height = debounced_height.value
+                if debounced_height.finished and debounced_height.value is not None:
+                    fig_model.height = debounced_height.value
 
     def get_height():
-        return layout["h"] * 45 - 90
+        # Scale figure height with grid rows; tuned for h=9 cards to keep plot area near full.
+        return layout["h"] * 45 - 45
 
     height = sl.use_memo(get_height, dependencies=[layout["h"]])
 
@@ -204,7 +204,9 @@ def add_common_effects(
                   dependencies=[df, plotstate.x.value, plotstate.y.value])
 
     try:
-        sl.use_effect(update_height, dependencies=[debounced_height.finished])
+        sl.use_effect(update_height,
+                  dependencies=[debounced_height.finished,
+                        debounced_height.value])
         sl.use_effect(update_flipx, dependencies=[plotstate.flipx.value])
         if plotstate.plottype != "histogram":
             sl.use_effect(update_flipy, dependencies=[plotstate.flipy.value])

--- a/src/sdss_explorer/dashboard/components/views/plot_settings.py
+++ b/src/sdss_explorer/dashboard/components/views/plot_settings.py
@@ -15,11 +15,12 @@ from ..sidebar.autocomplete import SingleAutocomplete, AutocompleteSelect
 logger = logging.getLogger("dashboard")
 
 
-def show_settings(type: str, plotstate: PlotState):
+@sl.component
+def show_settings(plottype: str, plotstate: PlotState):
     """Wrapper to case switch logic for menus
 
     Args:
-        type: plottype, any of `'histogram','scatter','heatmap'`
+        plottype: any of `'histogram','scatter','heatmap'`
         plotstate: plot variables
 
     """
@@ -49,15 +50,15 @@ def show_settings(type: str, plotstate: PlotState):
             value=name,
             on_value=plotstate.update_subset,
         )
-        if (type == "stats") or (type == "targets"):
+        if (plottype == "stats") or (plottype == "targets"):
             TableMenu(plotstate)
         else:
             with sl.Columns([1, 1]):
-                if type == "scatter":
+                if plottype == "scatter":
                     ScatterMenu(plotstate, columns)
-                elif type == "histogram":
+                elif plottype == "histogram":
                     HistogramMenu(plotstate, columns)
-                elif type == "heatmap":
+                elif plottype == "heatmap":
                     HeatmapMenu(plotstate, columns)
                 CommonSettings(plotstate)
     return

--- a/src/sdss_explorer/dashboard/components/views/plots.py
+++ b/src/sdss_explorer/dashboard/components/views/plots.py
@@ -1,16 +1,15 @@
 """Individual plot components"""
 
 import asyncio
-import operator
 import logging
+import operator
 from functools import reduce
 
 import numpy as np
-import solara as sl
 import pandas as pd
-import vaex as vx
 import reacton.ipyvuetify as rv
-from reacton.ipyvuetify import ValueElement
+import solara as sl
+import vaex as vx
 from bokeh.models import (
     HoverTool,
     Quad,
@@ -18,37 +17,36 @@ from bokeh.models import (
     Scatter,
 )
 from bokeh.plotting import ColumnDataSource
+from reacton.ipyvuetify import ValueElement
 
+from ...dataclass import Alert, GridState, PlotState, SubsetState, VCData, use_subset
 from .dataframe import ModdedDataTable, TargetsDataTable, format_targets
-from .plot_settings import show_settings
-from .plot_utils import (
-    add_all_tools,
-    add_callbacks,
-    check_categorical,
-    calculate_range,
-    generate_color_mapper,
-    generate_tooltips,
-    add_axes,
-    add_colorbar,
-    generate_plot,
-)
 from .figurebokeh import FigureBokeh
-from .plot_themes import LIGHTTHEME, DARKTHEME
-from .plot_effects import (
-    add_histogram_effects,
-    add_scatter_effects,
-    add_heatmap_effects,
-    add_common_effects,
-)
 from .plot_actions import (
-    reset_range,
     aggregate_data,
     fetch_data,
+    reset_range,
     update_mapping,
     update_tooltips,
 )
-
-from ...dataclass import PlotState, SubsetState, GridState, use_subset, Alert, VCData
+from .plot_effects import (
+    add_common_effects,
+    add_heatmap_effects,
+    add_histogram_effects,
+    add_scatter_effects,
+)
+from .plot_themes import DARKTHEME, LIGHTTHEME
+from .plot_utils import (
+    add_all_tools,
+    add_axes,
+    add_callbacks,
+    add_colorbar,
+    calculate_range,
+    check_categorical,
+    generate_color_mapper,
+    generate_plot,
+    generate_tooltips,
+)
 
 logger = logging.getLogger("dashboard")
 
@@ -56,7 +54,6 @@ logger = logging.getLogger("dashboard")
 # NOTE: must be initialized here to avoid circular imports
 index_context = sl.create_context(0)
 """context: used for tracing parent card in the grid for height resizing"""
-
 
 
 @sl.component()
@@ -71,16 +68,14 @@ def show_plot(plottype, plotstate: PlotState):
     # NOTE: force set to grey darken-3 colour for visibility of card against grey darken-4 background
     dark = sl.lab.use_dark_effective()
     with rv.Card(
-            class_="grey darken-3" if dark else "grey lighten-3",
-            style_="width: 100%; height: 100%;",
+        class_="grey darken-3" if dark else "grey lighten-3",
+        style_="width: 100%; height: 100%;",
     ) as main:
         df = SubsetState.subsets.value[plotstate.subset.value].df
 
         if df is not None:
             with rv.CardText():
-                with sl.Column(classes=[
-                        "grey darken-3" if dark else "grey lighten-3"
-                ]):
+                with sl.Column(classes=["grey darken-3" if dark else "grey lighten-3"]):
                     if plottype == "histogram":
                         HistogramPlot(plotstate)
                     elif plottype == "heatmap":
@@ -139,7 +134,8 @@ def HistogramPlot(plotstate: PlotState) -> ValueElement:
                 "left": edges[:-1],
                 "right": edges[1:],
                 "y": counts,
-            })
+            }
+        )
 
     source = sl.use_memo(generate_cds, dependencies=[])
 
@@ -234,7 +230,7 @@ def HeatmapPlot(plotstate: PlotState) -> ValueElement:
         for axis in {"x", "y", "color"}:
             col = getattr(plotstate, axis).value
             if check_categorical(col):
-                update_mapping(plotstate, axis="x")
+                update_mapping(plotstate, dff, axis="x")
         try:
             color, x_centers, y_centers, _ = aggregate_data(plotstate, dff)
         except Exception as e:
@@ -248,7 +244,8 @@ def HeatmapPlot(plotstate: PlotState) -> ValueElement:
                 "x": np.repeat(x_centers, len(y_centers)),
                 "y": np.tile(y_centers, len(x_centers)),
                 "color": color.flatten(),
-            })
+            }
+        )
 
     source = sl.use_memo(generate_cds, [])
 
@@ -275,10 +272,7 @@ def HeatmapPlot(plotstate: PlotState) -> ValueElement:
             height=abs(ylimits[1] - ylimits[0]) / plotstate.nbins.value,
             dilate=True,
             line_color=None,
-            fill_color={
-                "field": "color",
-                "transform": mapper
-            },
+            fill_color={"field": "color", "transform": mapper},
         )
         add_colorbar(plotstate, p, mapper, source.data["color"])
         gr = p.add_glyph(source, glyph)
@@ -359,7 +353,8 @@ def ScatterPlot(plotstate: PlotState) -> ValueElement:
             xmax = np.nanmax(lims)
             xmin = np.nanmin(lims)
             xfilter = df[
-                f"(({plotstate.x.value} > {xmin}) & ({plotstate.x.value} < {xmax}))"]
+                f"(({plotstate.x.value} > {xmin}) & ({plotstate.x.value} < {xmax}))"
+            ]
         except Exception as e:
             pass
         try:
@@ -368,7 +363,8 @@ def ScatterPlot(plotstate: PlotState) -> ValueElement:
             ymax = np.nanmax(lims)
             ymin = np.nanmin(lims)
             yfilter = df[
-                f"(({plotstate.y.value} > {ymin}) & ({plotstate.y.value} < {ymax}))"]
+                f"(({plotstate.y.value} > {ymin}) & ({plotstate.y.value} < {ymax}))"
+            ]
 
         except Exception as e:
             pass
@@ -381,17 +377,16 @@ def ScatterPlot(plotstate: PlotState) -> ValueElement:
         return combined
 
     # update on dataset (df) change, or range update
-    local_filter = sl.use_memo(update_filter,
-                               dependencies=[df, ranges[0], ranges[1]])
+    local_filter = sl.use_memo(update_filter, dependencies=[df, ranges[0], ranges[1]])
 
     async def debounced_filter():
         await asyncio.sleep(0.05)
         return local_filter
 
     # debounced output
-    debounced_local_filter = sl.lab.use_task(debounced_filter,
-                                             dependencies=[local_filter],
-                                             prefer_threaded=False)
+    debounced_local_filter = sl.lab.use_task(
+        debounced_filter, dependencies=[local_filter], prefer_threaded=False
+    )
 
     # combine the filters every render
     filters = []
@@ -429,12 +424,14 @@ def ScatterPlot(plotstate: PlotState) -> ValueElement:
             y = [1, 2, 3, 4]
             color = [1, 2, 3, 4]
             sdss_id = [1, 2, 3, 4]
-        source = ColumnDataSource(data={
-            "x": x,
-            "y": y,
-            "color": color,
-            "sdss_id": sdss_id,
-        })
+        source = ColumnDataSource(
+            data={
+                "x": x,
+                "y": y,
+                "color": color,
+                "sdss_id": sdss_id,
+            }
+        )
         logger.debug("cds = " + str(source.data))
         return source
 
@@ -453,13 +450,9 @@ def ScatterPlot(plotstate: PlotState) -> ValueElement:
         mapper = generate_color_mapper(plotstate, dff=dff)
 
         # add glyph
-        glyph = Scatter(x="x",
-                        y="y",
-                        size=8,
-                        fill_color={
-                            "field": "color",
-                            "transform": mapper
-                        })
+        glyph = Scatter(
+            x="x", y="y", size=8, fill_color={"field": "color", "transform": mapper}
+        )
         p.add_glyph(source, glyph)
         add_colorbar(plotstate, p, mapper, source.data["color"])
 
@@ -555,9 +548,9 @@ def StatisticsTable(state):
             dfd = pd.DataFrame({"error": ["no"], "encountered": ["data"]})
         return dfd
 
-    result = sl.lab.use_task(generate_describe,
-                             dependencies=[filter, columns,
-                                           len(columns)])
+    result = sl.lab.use_task(
+        generate_describe, dependencies=[filter, columns, len(columns)]
+    )
 
     def remove_column(name):
         """Removes column from column list"""
@@ -570,13 +563,13 @@ def StatisticsTable(state):
                 q = i
                 break
 
-        set_columns(columns[:q] + columns[q + 1:])
+        set_columns(columns[:q] + columns[q + 1 :])
 
     column_actions = [
         # TODO: a more complex action in here?
-        sl.ColumnAction(icon="mdi-delete",
-                        name="Remove column",
-                        on_click=remove_column),
+        sl.ColumnAction(
+            icon="mdi-delete", name="Remove column", on_click=remove_column
+        ),
     ]
 
     sl.ProgressLinear(result.pending)

--- a/src/sdss_explorer/dashboard/components/views/plots.py
+++ b/src/sdss_explorer/dashboard/components/views/plots.py
@@ -58,37 +58,6 @@ index_context = sl.create_context(0)
 """context: used for tracing parent card in the grid for height resizing"""
 
 
-@sl.component()
-def PlotToolbarMenu(plottype, plotstate: PlotState, del_func):
-    """Compact settings menu for use in the grid's top drag toolbar."""
-    with sl.Column(gap="0px",
-                   style={
-                       "padding": "0px",
-                       "margin": "0px",
-                       "min-width": "22px",
-                   }) as main:
-        btn = sl.Button(
-            icon_name="mdi-settings",
-            outlined=False,
-            classes=["ma-0 pa-0 white--text"],
-            style={
-                "min-width": "20px",
-                "width": "20px",
-                "height": "20px",
-            },
-        )
-
-        with sl.lab.Menu(activator=btn, close_on_content_click=False):
-            with sl.Card(margin=0):
-                show_settings(plottype, plotstate)
-                sl.Button(
-                    icon_name="mdi-delete",
-                    color="red",
-                    block=True,
-                    on_click=del_func,
-                )
-    return main
-
 
 @sl.component()
 def show_plot(plottype, plotstate: PlotState):

--- a/src/sdss_explorer/dashboard/components/views/plots.py
+++ b/src/sdss_explorer/dashboard/components/views/plots.py
@@ -59,37 +59,53 @@ index_context = sl.create_context(0)
 
 
 @sl.component()
-def show_plot(plottype, del_func, **kwargs):
-    """Helper function to show a specific plot type with its settings. Wraps all into card.
+def PlotToolbarMenu(plottype, plotstate: PlotState, del_func):
+    """Compact settings menu for use in the grid's top drag toolbar."""
+    with sl.Column(gap="0px",
+                   style={
+                       "padding": "0px",
+                       "margin": "0px",
+                       "min-width": "22px",
+                   }) as main:
+        btn = sl.Button(
+            icon_name="mdi-settings",
+            outlined=False,
+            classes=["ma-0 pa-0 white--text"],
+            style={
+                "min-width": "20px",
+                "width": "20px",
+                "height": "20px",
+            },
+        )
 
-    Note:
-        `PlotState` is instantiated here.
+        with sl.lab.Menu(activator=btn, close_on_content_click=False):
+            with sl.Card(margin=0):
+                show_settings(plottype, plotstate)
+                sl.Button(
+                    icon_name="mdi-delete",
+                    color="red",
+                    block=True,
+                    on_click=del_func,
+                )
+    return main
+
+
+@sl.component()
+def show_plot(plottype, plotstate: PlotState):
+    """Helper function to show a specific plot type with its settings. Wraps all into card.
 
     Args:
         plottype (str): plot type
-        del_func (Callable): callable to delete this plot from the grid.
-        kwargs (kwargs): overload for plot variable setup
+        plotstate (PlotState): pre-instantiated plot state from the parent view card
 
     """
     # NOTE: force set to grey darken-3 colour for visibility of card against grey darken-4 background
     dark = sl.lab.use_dark_effective()
     with rv.Card(
             class_="grey darken-3" if dark else "grey lighten-3",
-            style_="width: 100%; height: 100%",
+            style_="width: 100%; height: 100%;",
     ) as main:
-        # NOTE: current key has to be memoized outside the instantiation (why I couldn't tell you)
-        current_key = sl.use_memo(
-            lambda: list(SubsetState.subsets.value.keys())[-1],
-            dependencies=[])
-        plotstate = PlotState(plottype, current_key, **kwargs)
-        df = SubsetState.subsets.value[current_key].df
-
-        def add_to_grid():
-            """Adds a pointer/reference to PlotState instance in GridState for I/O."""
-            GridState.states.set(list(GridState.states.value + [plotstate]))
-            return None
-
-        sl.use_memo(add_to_grid, dependencies=[])  # runs once
+        df = SubsetState.subsets.value[plotstate.subset.value].df
 
         if df is not None:
             with rv.CardText():
@@ -106,23 +122,6 @@ def show_plot(plottype, del_func, **kwargs):
                         StatisticsTable(plotstate)
                     elif plottype == "targets":
                         TargetsTable(plotstate)
-                    btn = sl.Button(
-                        icon_name="mdi-settings",
-                        outlined=False,
-                        classes=[
-                            "grey darken-3" if dark else "grey lighten-3"
-                        ],
-                    )
-                    with sl.lab.Menu(activator=btn,
-                                     close_on_content_click=False):
-                        with sl.Card(margin=0):
-                            show_settings(plottype, plotstate)
-                            sl.Button(
-                                icon_name="mdi-delete",
-                                color="red",
-                                block=True,
-                                on_click=del_func,
-                            )
     return main
 
 

--- a/src/sdss_explorer/dashboard/dataclass/gridstate.py
+++ b/src/sdss_explorer/dashboard/dataclass/gridstate.py
@@ -1,6 +1,7 @@
 """Grid layout dataclass"""
 
 import solara as sl
+from typing import Optional
 
 from .state import State
 
@@ -15,13 +16,25 @@ class GridData:
     Attributes:
         grid_layout (sl.Reactive[list[dict[str,int]]]): list of grid layout properties per item
         objects (sl.Reactive[list[Any]]): list of widgets to render
+        toolbar_objects (sl.Reactive[list[Any]]): list of toolbar widgets to render in each grid item's top bar
         states (sl.Reactive[list[PlotState]]): list of states, for exporting
         index (sl.Reactive[int]): index, used for ensuring unique state between widgets
     """
 
-    def __init__(self, objects=[], layout=[], states=[]) -> None:
+    def __init__(
+        self,
+        objects: Optional[list] = None,
+        toolbar_objects: Optional[list] = None,
+        layout: Optional[list] = None,
+        states: Optional[list] = None,
+    ) -> None:
+        objects = objects or []
+        toolbar_objects = toolbar_objects or []
+        layout = layout or []
+        states = states or []
         self.grid_layout = sl.reactive(layout)
         self.objects = sl.reactive(objects)
+        self.toolbar_objects = sl.reactive(toolbar_objects)
         self.states = sl.reactive(states)
         self.index = sl.reactive(len(objects))
 

--- a/src/sdss_explorer/dashboard/dataclass/gridstate.py
+++ b/src/sdss_explorer/dashboard/dataclass/gridstate.py
@@ -16,7 +16,6 @@ class GridData:
     Attributes:
         grid_layout (sl.Reactive[list[dict[str,int]]]): list of grid layout properties per item
         objects (sl.Reactive[list[Any]]): list of widgets to render
-        toolbar_objects (sl.Reactive[list[Any]]): list of toolbar widgets to render in each grid item's top bar
         states (sl.Reactive[list[PlotState]]): list of states, for exporting
         index (sl.Reactive[int]): index, used for ensuring unique state between widgets
     """
@@ -24,17 +23,14 @@ class GridData:
     def __init__(
         self,
         objects: Optional[list] = None,
-        toolbar_objects: Optional[list] = None,
         layout: Optional[list] = None,
         states: Optional[list] = None,
     ) -> None:
         objects = objects or []
-        toolbar_objects = toolbar_objects or []
         layout = layout or []
         states = states or []
         self.grid_layout = sl.reactive(layout)
         self.objects = sl.reactive(objects)
-        self.toolbar_objects = sl.reactive(toolbar_objects)
         self.states = sl.reactive(states)
         self.index = sl.reactive(len(objects))
 

--- a/src/sdss_explorer/dashboard/dataclass/state.py
+++ b/src/sdss_explorer/dashboard/dataclass/state.py
@@ -67,6 +67,7 @@ def open_file(filename):
     if datapath is None:
         return None
 
+    logger.info("opening file %s", filename)
     # TODO: verify auth status when attempting to load a working group dataset
     try:
         dataset = vx.open(f"{datapath}/{filename}")
@@ -89,6 +90,21 @@ def open_explorer_file(release: str, datatype: str):
     return open_file(f"{release}/explorerAll{datatype.capitalize()}-{vastra}.hdf5")
 
 
+def open_mapping_file(release: str):
+    """Release-aware vaex open wrapper for mapping parquet files."""
+    release = (release or "dr19").lower()
+    primary = f"{release}/mappings_{release}.parquet"
+    dataset = open_file(primary)
+    if dataset is not None:
+        return dataset
+
+    # Backward compatibility for older layouts.
+    backup = open_file(f"mappings_{release}.parquet")
+    if backup is not None:
+        return backup
+    return open_file("mappings.parquet")
+
+
 def load_datamodel(release: str = None) -> pd.DataFrame | None:
     """Loads a given compiled datamodel, used in conjunction with the column glossary"""
     datapath = settings.datapath
@@ -101,24 +117,27 @@ def load_datamodel(release: str = None) -> pd.DataFrame | None:
     # TODO: this is globally set on app start; these needs to be set dynamically by the app
     # file = "ipl3_partial.json"
     release = None if release == "None" else release
-    release = release or "dr19"
-    file = f"{release.lower()}_dminfo.json"
+    release = (release or "dr19").lower()
+    file = f"{release}/{release}_dminfo.json"
+    backup = f"{release}_dminfo.json"
 
     path = pathlib.Path(f"{settings.datapath}/{file}")
-    if not path.exists():
+    back = pathlib.Path(f"{settings.datapath}/{backup}")
+    if not path.exists() and not back.exists():
         logger.critical(
-            "Expected to find %s for column glossary datamodel, didn't find it.",
-            path)
+            "Expected to find %s for column glossary datamodel, didn't find it. Nor in backup %s",
+            path, back)
         return None
 
+    target = file if path.exists() else backup
     try:
-        with open(f"{settings.datapath}/{file}", "r", encoding="utf-8") as f:
+        with open(f"{settings.datapath}/{target}", "r", encoding="utf-8") as f:
             data = json.load(f).values()
     except Exception as e:
         logger.debug("caught exception on datamodel loader: %s", e)
         return None
     else:
-        logger.info("successfully loaded datamodel")
+        logger.info("successfully loaded datamodel for release %s", release)
         return pd.DataFrame(data)  # TODO: back to vaex
 
 
@@ -142,10 +161,8 @@ class StateData:
         self._datatype = sl.reactive(cast(str, None))
 
         # globally shared, read only files
-        self.mapping = sl.reactive(
-            open_file("mappings.parquet"))  # mappings for bitmasks
-        self.datamodel = sl.reactive(load_datamodel(
-            self.release))  # datamodel spec
+        self.mapping = sl.reactive(cast(vx.DataFrame, None))
+        self.datamodel = sl.reactive(cast(pd.DataFrame, None))
 
         # adaptively rerendered on changes; set on startup in app root
         self.df = sl.reactive(cast(vx.DataFrame, None))  # main datafile
@@ -167,6 +184,12 @@ class StateData:
             release = self.release
         if not datatype:
             datatype = self.datatype
+
+        release = (release or "dr19").lower()
+
+        # Keep auxiliary files in sync with the active release.
+        self.mapping.set(open_mapping_file(release))
+        self.datamodel.set(load_datamodel(release))
 
         # start with standard open operation
         # TODO: redux version via envvar?

--- a/src/sdss_explorer/dashboard/dataclass/state.py
+++ b/src/sdss_explorer/dashboard/dataclass/state.py
@@ -1,17 +1,17 @@
 """Main application state variables"""
 
+import json
 import logging
 import pathlib
-import json
 from typing import Optional, cast
 
 import pandas as pd
 import solara as sl
 import vaex as vx
 
-from .subsetstore import SubsetStore
 from ...util import settings
 from ...util.util import resolve_vastra
+from .subsetstore import SubsetStore
 
 logger = logging.getLogger("dashboard")
 
@@ -44,8 +44,7 @@ def load_column_json(release: str, datatype: str) -> dict | None:
     file = f"{release}/columnsAll{datatype.capitalize()}-{vastra}.json"
     path = pathlib.Path(f"{datapath}/{file}")
     if not path.exists():
-        logger.critical(
-            "Expected to find %s for column lookup, didn't find it.", file)
+        logger.critical("Expected to find %s for column lookup, didn't find it.", file)
         return None
 
     with open(path, "r", encoding="utf-8") as f:
@@ -76,8 +75,7 @@ def open_file(filename):
         )  # shuffle to ensure skyplot looks nice, constant seed for reproducibility
         return dataset
     except FileNotFoundError:
-        logger.critical("Expected to find %s for dataframe, didn't find it.",
-                        filename)
+        logger.critical("Expected to find %s for dataframe, didn't find it.", filename)
         return None
     except Exception as e:
         logger.debug("caught exception on dataframe load: %s", e)
@@ -126,7 +124,9 @@ def load_datamodel(release: str = None) -> pd.DataFrame | None:
     if not path.exists() and not back.exists():
         logger.critical(
             "Expected to find %s for column glossary datamodel, didn't find it. Nor in backup %s",
-            path, back)
+            path,
+            back,
+        )
         return None
 
     target = file if path.exists() else backup
@@ -166,8 +166,7 @@ class StateData:
 
         # adaptively rerendered on changes; set on startup in app root
         self.df = sl.reactive(cast(vx.DataFrame, None))  # main datafile
-        self.columns = sl.reactive(cast(
-            dict, None))  # column glossary for guardrailing
+        self.columns = sl.reactive(cast(dict, None))  # column glossary for guardrailing
 
         # user-binded instances
         # NOTE: this approach allows UUID + subsetstore to be read-only
@@ -175,9 +174,9 @@ class StateData:
         self._kernel_id = sl.reactive(cast(str, None))
         self._subset_store = sl.reactive(SubsetStore())
 
-    def load_dataset(self,
-                     release: Optional[str] = None,
-                     datatype: Optional[str] = None) -> bool:
+    def load_dataset(
+        self, release: Optional[str] = None, datatype: Optional[str] = None
+    ) -> bool:
         """load the HDF5 dataset for the dashboard"""
         # use attributes if not manually overridden
         if not release:
@@ -246,14 +245,17 @@ class StateData:
     def __repr__(self) -> str:
         """Show relevant properties of class as string."""
         return "\n".join(
-            f"{k:15}: {v}" for k, v in {
+            f"{k:15}: {v}"
+            for k, v in {
                 "uuid": self.uuid,
                 "kernel_id": self.kernel_id,
                 "df": hex(id(self.df.value)),  # dataframe mem address
                 "subset_backend": hex(id(self.subset_store)),
                 "release": self.release,
                 "datatype": self.datatype,
-            }.items())
+            }.items()
+        )
+
 
 State = StateData()
 """Specific StateData instance used for app"""

--- a/src/sdss_explorer/dashboard/dataclass/state.py
+++ b/src/sdss_explorer/dashboard/dataclass/state.py
@@ -1,7 +1,6 @@
 """Main application state variables"""
 
 import logging
-import os
 import pathlib
 import json
 from typing import Optional, cast
@@ -12,6 +11,7 @@ import vaex as vx
 
 from .subsetstore import SubsetStore
 from ...util import settings
+from ...util.util import resolve_vastra
 
 logger = logging.getLogger("dashboard")
 
@@ -19,7 +19,6 @@ logger = logging.getLogger("dashboard")
 if sl.server.settings.main.mode == "production":
     vx.logging.remove_handler()  # force remove handler on production instance
 
-VASTRA = settings.vastra
 DATAPATH = settings.datapath
 
 if DATAPATH is None:
@@ -41,7 +40,8 @@ def load_column_json(release: str, datatype: str) -> dict | None:
     if datapath is None:
         return None
 
-    file = f"{release}/columnsAll{datatype.capitalize()}-{VASTRA}.json"
+    vastra = resolve_vastra(release)
+    file = f"{release}/columnsAll{datatype.capitalize()}-{vastra}.json"
     path = pathlib.Path(f"{datapath}/{file}")
     if not path.exists():
         logger.critical(
@@ -81,6 +81,12 @@ def open_file(filename):
     except Exception as e:
         logger.debug("caught exception on dataframe load: %s", e)
         return None
+
+
+def open_explorer_file(release: str, datatype: str):
+    """Release-aware vaex open wrapper for release-specific datafiles."""
+    vastra = resolve_vastra(release)
+    return open_file(f"{release}/explorerAll{datatype.capitalize()}-{vastra}.hdf5")
 
 
 def load_datamodel(release: str = None) -> pd.DataFrame | None:
@@ -132,7 +138,7 @@ class StateData:
 
     def __init__(self):
         # app settings, underscored to hide prop
-        self._release = sl.reactive(cast(str, None))  # TODO: dr19
+        self._release = sl.reactive(cast(str, None))
         self._datatype = sl.reactive(cast(str, None))
 
         # globally shared, read only files
@@ -148,8 +154,8 @@ class StateData:
 
         # user-binded instances
         # NOTE: this approach allows UUID + subsetstore to be read-only
-        self._uuid = sl.reactive(sl.get_session_id())
-        self._kernel_id = sl.reactive(sl.get_kernel_id())
+        self._uuid = sl.reactive(cast(str, None))
+        self._kernel_id = sl.reactive(cast(str, None))
         self._subset_store = sl.reactive(SubsetStore())
 
     def load_dataset(self,
@@ -164,8 +170,7 @@ class StateData:
 
         # start with standard open operation
         # TODO: redux version via envvar?
-        df = open_file(
-            f"{release}/explorerAll{datatype.capitalize()}-{VASTRA}.hdf5")
+        df = open_explorer_file(release, datatype)
         columns = load_column_json(release, datatype)
 
         if (df is None) and (columns is None):
@@ -193,7 +198,7 @@ class StateData:
     def get_default_dataset(self) -> str:
         """Method version to get the default dataset of app (star or visit). Used for defaulting the Subset dataclass"""
         datatype = self._datatype.value
-        return "mwmlite" if datatype == "star" else "thepayne"
+        return "bossnet" if datatype == "star" else "thepayne"
 
     def get_df(self) -> vx.DataFrame:
         """Method version to get the dataframe. Used for defaulting the Subset dataclass"""
@@ -226,7 +231,6 @@ class StateData:
                 "release": self.release,
                 "datatype": self.datatype,
             }.items())
-
 
 State = StateData()
 """Specific StateData instance used for app"""

--- a/src/sdss_explorer/server/dataframe.py
+++ b/src/sdss_explorer/server/dataframe.py
@@ -6,12 +6,14 @@ import os
 
 import vaex as vx
 
+from functools import lru_cache
 from ..util.config import settings
 from ..util.util import resolve_vastra
 
 logger = logging.getLogger("server")
 
 
+@lru_cache
 def load_mappings(release: str):
     """Loads release-aware mappings parquet with backward-compatible fallbacks."""
     release = (release or "dr19").lower()

--- a/src/sdss_explorer/server/dataframe.py
+++ b/src/sdss_explorer/server/dataframe.py
@@ -6,6 +6,7 @@ import logging
 import vaex as vx
 
 from ..util.config import settings
+from ..util.util import resolve_vastra
 
 logger = logging.getLogger("server")
 
@@ -14,12 +15,13 @@ mappings = vx.open(os.path.join(settings.datapath, "mappings.parquet"))
 
 def load_columns(release: str, datatype: str, dataset: str):
     """Loads the given columns for a release and datatype"""
+    vastra = resolve_vastra(release)
     with open(
             os.path.join(
                 settings.datapath,
                 release,
-                f"columnsAll{datatype.capitalize()}-{settings.vastra}.json",
-            )) as f:
+                f"columnsAll{datatype.capitalize()}-{vastra}.json",
+            ), "r", encoding="utf-8") as f:
         columns = json.load(f)
     return columns[dataset]
 
@@ -31,6 +33,7 @@ def load_dataframe(
     dataroot_dir = settings.datapath
     if dataroot_dir:
         logger.debug("opening dataframe")
+        vastra = resolve_vastra(release)
         cols = load_columns(release, datatype, dataset)
         # TODO: when we change the filegenerator, fix this here
         validCols = [
@@ -41,7 +44,7 @@ def load_dataframe(
             os.path.join(
                 dataroot_dir,
                 release,
-                f"explorerAll{datatype.capitalize()}-{settings.vastra}.hdf5",
+                f"explorerAll{datatype.capitalize()}-{vastra}.hdf5",
             ))
         dff = df[df[f"pipeline == '{dataset}'"]].extract()
         logger.debug("loaded dataframe!")

--- a/src/sdss_explorer/server/dataframe.py
+++ b/src/sdss_explorer/server/dataframe.py
@@ -1,8 +1,9 @@
 """Interface with dataframe"""
 
 import json
-import os
 import logging
+import os
+
 import vaex as vx
 
 from ..util.config import settings
@@ -29,18 +30,21 @@ def load_columns(release: str, datatype: str, dataset: str):
     """Loads the given columns for a release and datatype"""
     vastra = resolve_vastra(release)
     with open(
-            os.path.join(
-                settings.datapath,
-                release,
-                f"columnsAll{datatype.capitalize()}-{vastra}.json",
-            ), "r", encoding="utf-8") as f:
+        os.path.join(
+            settings.datapath,
+            release,
+            f"columnsAll{datatype.capitalize()}-{vastra}.json",
+        ),
+        "r",
+        encoding="utf-8",
+    ) as f:
         columns = json.load(f)
     return columns[dataset]
 
 
 def load_dataframe(
-        release: str, datatype: str,
-        dataset: str) -> tuple[vx.DataFrame | None, list[str] | None]:
+    release: str, datatype: str, dataset: str
+) -> tuple[vx.DataFrame | None, list[str] | None]:
     """Loads base dataframe and applies dataset filter IMMEDIATELY to reduce memory usage"""
     dataroot_dir = settings.datapath
     if dataroot_dir:
@@ -49,15 +53,15 @@ def load_dataframe(
         cols = load_columns(release, datatype, dataset)
         # TODO: when we change the filegenerator, fix this here
         validCols = [
-            col for col in cols
-            if ("_flags" not in col) and (col != "pipeline")
+            col for col in cols if ("_flags" not in col) and (col != "pipeline")
         ]
         df = vx.open(
             os.path.join(
                 dataroot_dir,
                 release,
                 f"explorerAll{datatype.capitalize()}-{vastra}.hdf5",
-            ))
+            )
+        )
         dff = df[df[f"pipeline == '{dataset}'"]].extract()
         logger.debug("loaded dataframe!")
         return dff, validCols

--- a/src/sdss_explorer/server/dataframe.py
+++ b/src/sdss_explorer/server/dataframe.py
@@ -10,7 +10,19 @@ from ..util.util import resolve_vastra
 
 logger = logging.getLogger("server")
 
-mappings = vx.open(os.path.join(settings.datapath, "mappings.parquet"))
+
+def load_mappings(release: str):
+    """Loads release-aware mappings parquet with backward-compatible fallbacks."""
+    release = (release or "dr19").lower()
+    primary = os.path.join(settings.datapath, release, f"mappings_{release}.parquet")
+    if os.path.exists(primary):
+        return vx.open(primary)
+
+    backup = os.path.join(settings.datapath, f"mappings_{release}.parquet")
+    if os.path.exists(backup):
+        return vx.open(backup)
+
+    return vx.open(os.path.join(settings.datapath, "mappings.parquet"))
 
 
 def load_columns(release: str, datatype: str, dataset: str):

--- a/src/sdss_explorer/server/filter.py
+++ b/src/sdss_explorer/server/filter.py
@@ -1,20 +1,20 @@
-import os
 import gc
 import logging
+import operator
+import os
+from datetime import datetime
+from functools import reduce
 from typing import ParamSpec
 from uuid import UUID
-import operator
-from functools import reduce
-from datetime import datetime
 
-from .dataframe import load_dataframe, load_mappings
 from ..util.config import settings
 from ..util.filters import (
     filter_carton_mapper,
-    filter_flags,
     filter_crossmatch,
     filter_expression,
+    filter_flags,
 )
+from .dataframe import load_dataframe, load_mappings
 
 _P = ParamSpec("_P")
 logger = logging.getLogger("server")
@@ -63,7 +63,8 @@ def filter_dataframe(
     filters = list()
 
     # generic unpack; show to console
-    logger.debug("""requested %s/%s/%s%s
+    logger.debug(
+        """requested %s/%s/%s%s
                  expr:                 %s
                  carton:               %s
                  mapper:               %s
@@ -71,7 +72,20 @@ def filter_dataframe(
                  crossmatch(%s): %s...
                  combotype:            %s
                  invert:               %s
-                 """, release, datatype, dataset, uuid, expression, carton, mapper, flags, cmtype, crossmatch[:8], combotype, invert)
+                 """,
+        release,
+        datatype,
+        dataset,
+        uuid,
+        expression,
+        carton,
+        mapper,
+        flags,
+        cmtype,
+        crossmatch[:8],
+        combotype,
+        invert,
+    )
 
     # process list-like data
     if carton:
@@ -83,8 +97,7 @@ def filter_dataframe(
 
     # make all filters via utility funcs
     if expression:
-        filters.append(
-            filter_expression(dff, columns, expression, invert=invert))
+        filters.append(filter_expression(dff, columns, expression, invert=invert))
     if carton or mapper:
         cmp_filter = filter_carton_mapper(
             dff,

--- a/src/sdss_explorer/server/filter.py
+++ b/src/sdss_explorer/server/filter.py
@@ -7,7 +7,7 @@ import operator
 from functools import reduce
 from datetime import datetime
 
-from .dataframe import load_dataframe, mappings
+from .dataframe import load_dataframe, load_mappings
 from ..util.config import settings
 from ..util.filters import (
     filter_carton_mapper,
@@ -57,6 +57,7 @@ def filter_dataframe(
     """
     logger.debug("starting filter job")
     dff, columns = load_dataframe(release, datatype, dataset)
+    mappings = load_mappings(release)
     if (dff is None) or (columns is None):
         raise Exception("dataframe/columns load failed")
     filters = list()

--- a/src/sdss_explorer/server/filter.py
+++ b/src/sdss_explorer/server/filter.py
@@ -43,7 +43,7 @@ def filter_dataframe(
         uuid: unique job id
         release: data release
         datatype: datatype (star or visit)
-        dataset: specific dataset i.e. aspcap, spall, best
+        dataset: specific dataset i.e. aspcap, spall, mwmlite
         name: name of subset, used in generating output file
         expression: filter expression
         carton: comma-separated cartons
@@ -62,15 +62,15 @@ def filter_dataframe(
     filters = list()
 
     # generic unpack; show to console
-    logger.debug(f"""requested {release}/{datatype}/{dataset}{uuid}
-                 expr:                 {expression} 
-                 carton:               {carton} 
-                 mapper:               {mapper} 
-                 flags:                {flags}
-                 crossmatch({cmtype}): {crossmatch[:8]}...
-                 combotype:            {combotype}
-                 invert:               {invert}
-                 """)
+    logger.debug("""requested %s/%s/%s%s
+                 expr:                 %s
+                 carton:               %s
+                 mapper:               %s
+                 flags:                %s
+                 crossmatch(%s): %s...
+                 combotype:            %s
+                 invert:               %s
+                 """, release, datatype, dataset, uuid, expression, carton, mapper, flags, cmtype, crossmatch[:8], combotype, invert)
 
     # process list-like data
     if carton:

--- a/src/sdss_explorer/util/config.py
+++ b/src/sdss_explorer/util/config.py
@@ -1,6 +1,7 @@
 """Application settings. Places everything that is set by an envvar under a namespace."""
 
 import os
+from typing import Dict
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field
 
@@ -36,6 +37,16 @@ class Settings(BaseSettings):
     vastra: str = Field(default="0.6.0",
                         validation_alias="VASTRA",
                         description="Astra reduction versions to read.")
+
+    release_map: Dict[str, str] = Field(
+        default_factory=lambda: {
+            "ipl3": "0.6.0",
+            "dr19": "0.6.0",
+            "dr20": "0.8.1",
+        },
+        validation_alias="RELEASE_MAP",
+        description="Mapping of release name to Astra reduction version.",
+    )
 
     solara: bool = Field(
         default=False, validation_alias="EXPLORER_MOUNT_DASHBOARD",

--- a/src/sdss_explorer/util/config.py
+++ b/src/sdss_explorer/util/config.py
@@ -2,41 +2,59 @@
 
 import os
 from typing import Dict
-from pydantic_settings import BaseSettings, SettingsConfigDict
+
 from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """Global settings for webapp, defined by environment variables"""
+
     model_config = SettingsConfigDict(env_prefix="explorer_")
-    nworkers: int = Field(default=2, description="How many gunicorn/uvicorn workers to run with.")
+    nworkers: int = Field(
+        default=2, description="How many gunicorn/uvicorn workers to run with."
+    )
 
-    nprocesses: int = Field(default=2, description="How many export processes to run concurrently. The max possible will on memory spec of the machine.")
+    nprocesses: int = Field(
+        default=2,
+        description="How many export processes to run concurrently. The max possible will on memory spec of the machine.",
+    )
 
-    home: str = Field(default=os.path.expanduser("~"),
-                      validation_alias="VAEX_HOME",
-                      description="The home directory for caching and fingerprinting by vaex. Defaults to `$HOME`.")
+    home: str = Field(
+        default=os.path.expanduser("~"),
+        validation_alias="VAEX_HOME",
+        description="The home directory for caching and fingerprinting by vaex. Defaults to `$HOME`.",
+    )
 
-    logpath: str = Field(default=os.path.expanduser("~"),
-                         description="The home directory for logs. Defaults to `$HOME`.")
+    logpath: str = Field(
+        default=os.path.expanduser("~"),
+        description="The home directory for logs. Defaults to `$HOME`.",
+    )
 
-    loglevel: str = Field(default="INFO",
-                          description="The log level for stdout/err. Defaults to INFO.")
+    loglevel: str = Field(
+        default="INFO", description="The log level for stdout/err. Defaults to INFO."
+    )
 
-    datapath: str = Field(default="./home",
-                          description="The datapath to explorer files. Expects to be formatted in `./[release]/[explorer|columns]All[datatype]-[vastra].[hdf5|parquet]`")
+    datapath: str = Field(
+        default="./home",
+        description="The datapath to explorer files. Expects to be formatted in `./[release]/[explorer|columns]All[datatype]-[vastra].[hdf5|parquet]`",
+    )
 
-    scratch: str = Field(default="./scratch",
-                         description="The datapath to a scratch space for custom summary file outputs.")
+    scratch: str = Field(
+        default="./scratch",
+        description="The datapath to a scratch space for custom summary file outputs.",
+    )
 
     dev: bool = Field(
         default=False,
-        description="Whether to consider the environment a development one or not. Also checks against whether server instance is production for dashboard."
+        description="Whether to consider the environment a development one or not. Also checks against whether server instance is production for dashboard.",
     )
 
-    vastra: str = Field(default="0.6.0",
-                        validation_alias="VASTRA",
-                        description="Astra reduction versions to read.")
+    vastra: str = Field(
+        default="0.6.0",
+        validation_alias="VASTRA",
+        description="Astra reduction versions to read.",
+    )
 
     release_map: Dict[str, str] = Field(
         default_factory=lambda: {
@@ -49,16 +67,19 @@ class Settings(BaseSettings):
     )
 
     solara: bool = Field(
-        default=False, validation_alias="EXPLORER_MOUNT_DASHBOARD",
-        description="Whether to mount the dashboard in the FastAPI server instance."
+        default=False,
+        validation_alias="EXPLORER_MOUNT_DASHBOARD",
+        description="Whether to mount the dashboard in the FastAPI server instance.",
     )
 
-    api_url: str = Field(default="http://localhost:8050",
-                         description="API url for download server. Defaults to localhost on port 8050.")
+    api_url: str = Field(
+        default="http://localhost:8050",
+        description="API url for download server. Defaults to localhost on port 8050.",
+    )
 
     download_url: str = Field(
         default="https://bing.com/search?query=",
-        description="Public download URL for serving files. Defaults to bing (for fun)."
+        description="Public download URL for serving files. Defaults to bing (for fun).",
     )
 
 

--- a/src/sdss_explorer/util/filters.py
+++ b/src/sdss_explorer/util/filters.py
@@ -1,17 +1,16 @@
 """All filter conversion functions. Validation done in UI, but conversion to Expressions is done via these functions"""
 
-import operator
 import logging
+import operator
 import re
+
 import numpy as np
 import vaex as vx
 
 # TODO: get dashboard or main depending on context of functions
 logger = logging.getLogger("dashboard")
 
-__all__ = [
-    "check_flags", "filter_expression", "filter_carton_mapper", "filter_flags"
-]
+__all__ = ["check_flags", "filter_expression", "filter_carton_mapper", "filter_flags"]
 
 
 @vx.register_function(multiprocessing=True)
@@ -76,8 +75,7 @@ def filter_expression(
         illegals = ["eval", "exec", "import", "__main__"]
         for illegal in illegals:
             if illegal in expression:
-                logger.critical(
-                    "this user attempted to use ACE-like expressions!")
+                logger.critical("this user attempted to use ACE-like expressions!")
                 assert False, "Your session and IP has been logged."
 
         parts = re.split(r"(>=|<=|<|>|==|!=)", expr)
@@ -88,8 +86,9 @@ def filter_expression(
             assert (
                 re.fullmatch(r"<=|<", parts[1]) is not None
                 and re.fullmatch(r"<=|<", parts[3]) is not None
-            ), (f"expression {n} is invalid: not a proper 3-part inequality (a < col <= b)"
-                )
+            ), (
+                f"expression {n} is invalid: not a proper 3-part inequality (a < col <= b)"
+            )
 
             # check middle
             assert parts[2] in columns, (
@@ -126,7 +125,8 @@ def filter_expression(
             else:
                 assert False, f"expression {n} is invalid: one part must be column"
             assert re.match(r">=|<=|<|>|==|!=", parts[1]) is not None, (
-                f"expression {n} is invalid: middle is not comparator")
+                f"expression {n} is invalid: middle is not comparator"
+            )
 
             # change the expression in subexpression
             subexpressions[i] = "(" + expr + ")"
@@ -197,10 +197,9 @@ def filter_carton_mapper(
         return cmp_filter
 
 
-def filter_flags(df: vx.DataFrame,
-                 flags: list[str],
-                 dataset: str,
-                 invert: bool = False) -> vx.Expression | None:
+def filter_flags(
+    df: vx.DataFrame, flags: list[str], dataset: str, invert: bool = False
+) -> vx.Expression | None:
     """
     Generates a filter for flags
 
@@ -217,7 +216,7 @@ def filter_flags(df: vx.DataFrame,
             continue
         # boss-only pipeline exceptions for zwarning_flags filtering
         elif np.isin(
-                dataset,
+            dataset,
             ("spall", "lineforest"),
         ) and (flag == "purely non-flagged"):
             filters.append("zwarning_flags!=0")
@@ -237,8 +236,9 @@ def filter_flags(df: vx.DataFrame,
     return concat_filter
 
 
-def filter_crossmatch(df: vx.DataFrame, crossmatch: str,
-                      cmtype: str) -> vx.Expression | None:
+def filter_crossmatch(
+    df: vx.DataFrame, crossmatch: str, cmtype: str
+) -> vx.Expression | None:
     """
     Generates a filter for flags
 
@@ -257,8 +257,7 @@ def filter_crossmatch(df: vx.DataFrame, crossmatch: str,
         AssertionError: if users pass
 
     """
-    assert cmtype in crossmatchList.keys(
-    ), "unspported crossmatch column passed"
+    assert cmtype in crossmatchList.keys(), "unspported crossmatch column passed"
 
     # bhm doesnt fetch tic_v8's so flag
     if (cmtype == "tic_v8") and (df["pipeline"].unique()[0] == "spall"):
@@ -276,9 +275,7 @@ def filter_crossmatch(df: vx.DataFrame, crossmatch: str,
                 identifiers = crossmatch.lstrip().rstrip().split("\n")
             else:
                 # we have to make sure all are integers
-                identifiers = list(
-                    map(int,
-                        crossmatch.lstrip().rstrip().split("\n")))
+                identifiers = list(map(int, crossmatch.lstrip().rstrip().split("\n")))
         except Exception:
             # makes errors more informative
             raise ValueError("failed to convert to integer identifiers")

--- a/src/sdss_explorer/util/logger.py
+++ b/src/sdss_explorer/util/logger.py
@@ -1,8 +1,9 @@
 """Logging configuration and setup"""
 
-from os.path import join as pathjoin
 import logging
 import logging.config
+from os.path import join as pathjoin
+
 import solara as sl
 
 __all__ = ["setup_logging"]
@@ -73,8 +74,7 @@ def setup_logging(
                 "()":
                 # logging.Formatter,
                 MultiLineFormatter,  # use custom multi-line formatter
-                "format":
-                "%(asctime)s - %(name)s - %(levelname)s - %(kernel_id)s - %(message)s",  # standard format
+                "format": "%(asctime)s - %(name)s - %(levelname)s - %(kernel_id)s - %(message)s",  # standard format
             }
         },
         "handlers": {

--- a/src/sdss_explorer/util/util.py
+++ b/src/sdss_explorer/util/util.py
@@ -1,7 +1,7 @@
 """General utility functions"""
 
-import uuid
 import os
+import uuid
 
 import vaex as vx  # noqa
 

--- a/src/sdss_explorer/util/util.py
+++ b/src/sdss_explorer/util/util.py
@@ -5,9 +5,12 @@ import os
 
 import vaex as vx  # noqa
 
+from .config import settings
+
 __all__ = [
     "check_categorical",
     "generate_unique_key",
+    "resolve_vastra",
     "validate_release",
     "validate_pipeline",
 ]
@@ -39,6 +42,15 @@ def generate_unique_key(key: str = "") -> str:
         return str(uuid.uuid4())
 
     return key + make_uuid()
+
+
+def resolve_vastra(release: str | None) -> str:
+    """Resolve the Astra version from a release name.
+
+    Falls back to the global ``vastra`` setting if no release mapping exists.
+    """
+    key = (release or "").lower()
+    return settings.release_map.get(key, settings.vastra)
 
 
 def validate_release(path: str, release: str) -> bool:

--- a/src/sdss_explorer/vue/gridlayout_toolbar.vue
+++ b/src/sdss_explorer/vue/gridlayout_toolbar.vue
@@ -28,10 +28,15 @@
                    drag-ignore-from=".no-drag"
                    drag-allow-from=".v-toolbar"
         >
-            <v-toolbar color="blue-grey" title="Click on this toolbar to drag." height="18px"></v-toolbar>
-            <div v-if="!items[item.i]" 
-                :class="$vuetify.theme.dark ? 'bg-grey-darken-3' : 'bg-grey-lighten-3'" 
-                class="rounded elevation-2 pa-4 d-flex justify-center align-center" 
+            <v-toolbar color="blue-grey" title="Click on this toolbar to drag." height="22px" dense>
+              <v-spacer></v-spacer>
+              <v-btn icon small class="no-drag mr-1" @click.stop="openSettings(item.i)">
+                <span style="color: #ffffff; font-size: 25px; line-height: 25px; font-weight: 700;">⚙</span>
+              </v-btn>
+            </v-toolbar>
+            <div v-if="!items[item.i]"
+                :class="$vuetify.theme.dark ? 'bg-grey-darken-3' : 'bg-grey-lighten-3'"
+                class="rounded elevation-2 pa-4 d-flex justify-center align-center"
                 style="min-height: 150px">
               <v-progress-circular
                 indeterminate
@@ -61,6 +66,10 @@ module.exports = {
       this.gridlayout_loaded = true;
     },
     methods: {
+        openSettings(i) {
+          // Sync clicked grid-item id back to Python so ObjectGrid can open settings.
+          this.selected_settings_i = i;
+        },
         resizedEvent(i, newH, newW, newHPx, newWPx) {
           // this will cause bqplot to layout itself
           window.dispatchEvent(new Event('resize'));


### PR DESCRIPTION
This PR updates the explorer dashboard mostly to accommodate new DR20 data release.  It moves all file loading for the explorer files, datamodel and mapping files to when the dashboard first loads, not globally.  It adds a DR-to-astra version mapping, rather than making the astra version a global setting.  

It also moves the plot chart settings to the top toolbar and adjusts the v-card and chart size.  