### PR TITLE
updating some docs

### DIFF
--- a/docs/examples/crossmatch.md
+++ b/docs/examples/crossmatch.md
@@ -1,7 +1,7 @@
 ## Look at the spectra of some targets
 
 !!! note
-    All references to `best` should be substituted with the new `mwmlite`.
+    All references to `best` should be substituted with the new `mwmlite`.  This file only applies to SDSS DR19 and has been deprecated for all SDSS data releases DR20 and above.
 
 Let's say you have a couple of Source Identifiers from [Gaia](https://esa.gaia.int/) Data Release 3 that you want to check if they were surveyed by SDSS-V.
 

--- a/docs/examples/hr.md
+++ b/docs/examples/hr.md
@@ -1,7 +1,10 @@
 Let's create and compare a few color magnitude diagrams.
 
 !!! note
-    This guide is slightly outdated, but everything still applies. The plots just look different, really.  For example, all references to `best` in images here refer to `mwmlite`.
+    This guide is slightly outdated, but everything still applies. The plots just look different, really.  For example, all references to `best` in images here refer to `mwmlite`. This file only applies to SDSS DR19 and has been deprecated for all SDSS data releases DR20 and above.
+
+!!! note
+    This tutorial is DR19 specific.
 
 To start, we'll load the `mwmlite` reductions, which contain SDSS-V's best parameter estimates for all stars. This is automatically done when you load the app.
 

--- a/docs/examples/yso.md
+++ b/docs/examples/yso.md
@@ -1,5 +1,5 @@
 !!! note
-    All references to `best` should be substituted with the new `mwmlite`.
+    All references to `best` should be substituted with the new `mwmlite`. This file only applies to SDSS DR19 and has been deprecated for all SDSS data releases DR20 and above.
 
 Let's say we know what specific **Targeting Carton** we want to have a look at. We can directly select these cartons via the **Targeting Filters** menu.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ The Explorer is SDSS-V's interface for accessing and exploring Milky Way Mapper 
 Explorer is developed by SDSS-V, using `solara`, `fastapi`,`vaex`, and `bokeh`. Explorer was developed and designed by Riley Thai, and is maintained by the SDSS-V Data Visualization Team.
 
 !!! note
-    The examples and screenshots in these docs may reference the `best` Astra summary catalog file.  This file has now been named `mwmLite`.  In the live dashboard you will see reference to the `mwmlite` dataset.  This is the same as `best` in this documentation.
+    The examples and screenshots in these docs may reference the `best` Astra summary catalog file.  In SDSS DR19, this file was renamed to `mwmLite`.  In the live dashboard for DR19 you will see reference to the `mwmlite` dataset.  This is the same as `best` in this documentation. In all data releases DR20 and above, the `mwmLite` file has been deprecated and removed.
 
 Get started with our examples:
 


### PR DESCRIPTION
Updates some explorer docs with notes on the deprecated `mwmLite` file and DR19/DR20.  