### PR TITLE
switch scatter to use xy range for bounds

### DIFF
--- a/src/sdss_explorer/dashboard/components/sidebar/glossary.py
+++ b/src/sdss_explorer/dashboard/components/sidebar/glossary.py
@@ -2,6 +2,7 @@
 
 import os
 import glob
+import markdown
 import solara as sl
 from solara.alias import rv
 import numpy as np
@@ -63,6 +64,14 @@ class Help:
 @sl.component()
 def HelpBlurb():
     """Dialog popup to provide short help blurbs for the application. Expected to read markdown files."""
+
+    def _make_help_parser():
+        # Use a minimal parser for bundled help text to avoid
+        # environment-specific crashes in syntax highlighter stacks.
+        return markdown.Markdown(extensions=["tables", "toc", "fenced_code"])
+
+    help_md_parser = sl.use_memo(_make_help_parser, dependencies=[])
+
     with rv.AppBarNavIcon() as main:
         with sl.Tooltip("About the app + Help"):
             sl.Button(
@@ -83,7 +92,7 @@ def HelpBlurb():
                 with Tabs(value=Help.tab.value, on_value=Help.tab.set):
                     for label, (icon, text) in sorted(help_text.items()):
                         with Tab(label=label, icon_name=icon):
-                            sl.Markdown(text)
+                            sl.Markdown(text, md_parser=help_md_parser)
 
     return main
 

--- a/src/sdss_explorer/dashboard/components/views/plot_effects.py
+++ b/src/sdss_explorer/dashboard/components/views/plot_effects.py
@@ -179,14 +179,42 @@ def add_common_effects(
                     set_filter(combined)
 
                 elif plotstate.plottype == "scatter":
-                    # NOTE: pyarrow ChunkedArrays
+                    # NOTE: use bounds-based propagation (same behavior as heatmap)
+                    # to avoid exact point-matching filters that can create
+                    # stride-sensitive arrays in downstream histogram updates.
                     datax = source.data["x"].take(new)
                     datay = source.data["y"].take(new)
-                    colx = fetch_data(plotstate, df, axis="x")
-                    coly = fetch_data(plotstate, df, axis="y")
-                    newfilter = (colx.isin(datax)) & (coly.isin(datay))
-                    logger.debug(f"scatter: {str(newfilter)}")
-                    set_filter(newfilter)
+
+                    def _to_numpy(data):
+                        if hasattr(data, "to_numpy"):
+                            return data.to_numpy()
+                        return np.asarray(data)
+
+                    if check_categorical(plotstate.x.value):
+                        mapping = getattr(plotstate, "xmapping")
+                        colx = df[plotstate.x.value].map(mapping)
+                        xfilter = colx.isin(datax)
+                    else:
+                        colx = plotstate.x.value
+                        xvals = _to_numpy(datax)
+                        xmin = np.nanmin(xvals)
+                        xmax = np.nanmax(xvals)
+                        xfilter = (df[colx] >= xmin) & (df[colx] <= xmax)
+
+                    if check_categorical(plotstate.y.value):
+                        mapping = getattr(plotstate, "ymapping")
+                        coly = df[plotstate.y.value].map(mapping)
+                        yfilter = coly.isin(datay)
+                    else:
+                        coly = plotstate.y.value
+                        yvals = _to_numpy(datay)
+                        ymin = np.nanmin(yvals)
+                        ymax = np.nanmax(yvals)
+                        yfilter = (df[coly] >= ymin) & (df[coly] <= ymax)
+
+                    combined = xfilter & yfilter
+                    logger.debug(f"scatter(bounds): {str(combined)}")
+                    set_filter(combined)
             else:
                 logger.debug("unsetting filter")
                 set_filter(None)


### PR DESCRIPTION
Closes #130.  This PR switches the scatter xy filter to a range bound from exact clips, similar to the heatmap. This fixes the scatter-to-histogram cross-linking with the numpy stride error.   